### PR TITLE
feat: add in notification channels

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -45,7 +45,15 @@ class IgnoreModel:
     __prisma_model__ = "IgnoreModel"
 
 
+class NotificationChannels(typing.TypedDict, total=False):
+    realm_offline: int
+    player_watchlist: int
+
+
 class GuildConfig(PrismaGuildConfig):
+    if typing.TYPE_CHECKING:
+        notification_channels: NotificationChannels
+
     premium_code: typing.Optional["PremiumCode"] = None
 
     @classmethod

--- a/common/models.py
+++ b/common/models.py
@@ -20,6 +20,8 @@ import typing
 from datetime import UTC, datetime, timedelta
 from functools import cached_property
 
+from prisma import Json
+
 # i cannot tell you just how ridiculous this seems
 # prisma generates models on the fly??? just for typehinting???
 # i love it
@@ -73,10 +75,9 @@ class GuildConfig(PrismaGuildConfig):
         return bool(self.premium_code and self.premium_code.valid_code)
 
     async def save(self) -> None:
-        await self.prisma().update(
-            where={"guild_id": self.guild_id},
-            data=self.model_dump(exclude={"premium_code_id", "premium_code"}),  # type: ignore
-        )
+        data = self.model_dump(exclude={"premium_code_id", "premium_code"})
+        data["notification_channels"] = Json(data["notification_channels"])
+        await self.prisma().update(where={"guild_id": self.guild_id}, data=data)  # type: ignore
 
 
 EMOJI_DEVICE_NAMES = {

--- a/common/playerlist_utils.py
+++ b/common/playerlist_utils.py
@@ -374,6 +374,9 @@ async def eventually_invalidate(
 async def eventually_invalidate_watchlist(
     bot: utils.RealmBotBase, guild_config: models.GuildConfig
 ) -> None:
+    if not utils.FEATURE("EVENTUALLY_INVALIDATE"):
+        return
+
     num_times = await bot.redis.incr(f"invalid-watchlist-{guild_config.guild_id}")
 
     logger.info(
@@ -421,6 +424,9 @@ async def eventually_invalidate_watchlist(
 async def eventually_invalidate_realm_offline(
     bot: utils.RealmBotBase, guild_config: models.GuildConfig
 ) -> None:
+    if not utils.FEATURE("EVENTUALLY_INVALIDATE"):
+        return
+
     num_times = await bot.redis.incr(f"invalid-realm-offline-{guild_config.guild_id}")
 
     logger.info(

--- a/common/playerlist_utils.py
+++ b/common/playerlist_utils.py
@@ -335,6 +335,7 @@ async def eventually_invalidate(
         old_watchlist = guild_config.player_watchlist
         guild_config.player_watchlist = []
         guild_config.player_watchlist_role = None
+        guild_config.notification_channels = {}
         await guild_config.save()
         await bot.redis.delete(
             f"invalid-playerlist3-{guild_config.guild_id}",
@@ -364,6 +365,93 @@ async def eventually_invalidate(
                     " permissions, make sure the bot has `View Channel`, `Send"
                     " Messages`, and `Embed Links` enabled, and then re-set the"
                     " playerlist channel."
+                )
+
+                await chan.send(msg)
+
+
+# TODO: combine these into one somehow
+async def eventually_invalidate_watchlist(
+    bot: utils.RealmBotBase, guild_config: models.GuildConfig
+) -> None:
+    num_times = await bot.redis.incr(f"invalid-watchlist-{guild_config.guild_id}")
+
+    logger.info(
+        f"Increased invalid-watchlist for guild {guild_config.guild_id} to"
+        f" {num_times}/3."
+    )
+
+    await bot.redis.expire(f"invalid-watchlist-{guild_config.guild_id}", 172000)
+
+    if num_times >= 3:
+        logger.info(
+            f"Unlinking watchlist for guild {guild_config.guild_id} with"
+            f" {num_times}/3 invalidations."
+        )
+
+        old_watchlist = guild_config.player_watchlist
+        guild_config.player_watchlist = []
+        guild_config.player_watchlist_role = None
+        old_chan = guild_config.notification_channels.pop("player_watchlist", None)
+        await guild_config.save()
+
+        if guild_config.realm_id and old_watchlist:
+            for player_xuid in old_watchlist:
+                bot.player_watchlist_store[
+                    f"{guild_config.realm_id}-{player_xuid}"
+                ].discard(guild_config.guild_id)
+
+        if old_chan:
+            with contextlib.suppress(ipy.errors.HTTPException, AttributeError):
+                chan = await bot.fetch_channel(old_chan)
+                if not chan:
+                    return
+
+                msg = (
+                    "The player watchlist players and channel has been unlinked as the"
+                    " bot has not been able to properly send messages to it. Please"
+                    " check your permissions, make sure the bot has `View Channel`,"
+                    " `Send Messages`, and `Embed Links` enabled, and then re-set the"
+                    " watchlist and channel."
+                )
+
+                await chan.send(msg)
+
+
+async def eventually_invalidate_realm_offline(
+    bot: utils.RealmBotBase, guild_config: models.GuildConfig
+) -> None:
+    num_times = await bot.redis.incr(f"invalid-realm-offline-{guild_config.guild_id}")
+
+    logger.info(
+        f"Increased invalid-realm-offline for guild {guild_config.guild_id} to"
+        f" {num_times}/3."
+    )
+
+    await bot.redis.expire(f"invalid-realm-offline-{guild_config.guild_id}", 172000)
+
+    if num_times >= 3:
+        logger.info(
+            f"Unlinking Realm offline for guild {guild_config.guild_id} with"
+            f" {num_times}/3 invalidations."
+        )
+
+        guild_config.realm_offline_role = None
+        old_chan = guild_config.notification_channels.pop("realm_offline", None)
+        await guild_config.save()
+
+        if old_chan:
+            with contextlib.suppress(ipy.errors.HTTPException, AttributeError):
+                chan = await bot.fetch_channel(old_chan)
+                if not chan:
+                    return
+
+                msg = (
+                    "The Realm Offline role and channel has been unlinked as the bot"
+                    " has not been able to properly send messages to it. Please check"
+                    " your permissions, make sure the bot has `View Channel`, `Send"
+                    " Messages`, and `Embed Links` enabled, and then re-set the role"
+                    " and channel."
                 )
 
                 await chan.send(msg)

--- a/exts/guild_config.py
+++ b/exts/guild_config.py
@@ -246,7 +246,6 @@ class GuildConfig(utils.Extension):
         old_player_watchlist = config.player_watchlist
         config.player_watchlist = []
         config.player_watchlist_role = None
-        config.notification_channels = {}
 
         await config.save()
 

--- a/exts/guild_config.py
+++ b/exts/guild_config.py
@@ -246,6 +246,7 @@ class GuildConfig(utils.Extension):
         old_player_watchlist = config.player_watchlist
         config.player_watchlist = []
         config.player_watchlist_role = None
+        config.notification_channels = {}
 
         await config.save()
 
@@ -694,8 +695,8 @@ class GuildConfig(utils.Extension):
     @config.subcommand(
         sub_cmd_name="notification-channel",
         sub_cmd_description=(
-            "Sets (or reset) the channels used for certain notifications from the bot."
-            " Defaults to the playerlist channel."
+            "Sets/reset the channels used for notifications from the bot. Defaults to"
+            " the playerlist channel."
         ),
     )
     @ipy.check(pl_utils.has_linked_realm)

--- a/migrations/20230922031937_notification_channels/migration.sql
+++ b/migrations/20230922031937_notification_channels/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "realmguildconfig" ADD COLUMN     "notification_channels" JSONB NOT NULL DEFAULT '{}';

--- a/schema.prisma
+++ b/schema.prisma
@@ -22,6 +22,7 @@ model GuildConfig {
   live_online_channel   String?           @db.VarChar(75)
   player_watchlist_role BigInt?
   player_watchlist      String[]          @default([])
+  notification_channels Json              @db.JsonB @default("{}")
   premium_code      PremiumCode? @relation(fields: [premium_code_id], references: [id], onUpdate: NoAction)
 
   @@map("realmguildconfig")


### PR DESCRIPTION
These allow you to specify and redirect certain "notifications" from the bot into other channels.
This includes the Realm Offline and Player Watchlist notifications.