### PR TITLE
feat: add reoccurring leaderboard

### DIFF
--- a/common/models.py
+++ b/common/models.py
@@ -50,7 +50,7 @@ class IgnoreModel:
 class NotificationChannels(typing.TypedDict, total=False):
     realm_offline: int
     player_watchlist: int
-    reoccuring_leaderboard: int
+    reoccurring_leaderboard: int
 
 
 class GuildConfig(PrismaGuildConfig):

--- a/common/models.py
+++ b/common/models.py
@@ -50,6 +50,7 @@ class IgnoreModel:
 class NotificationChannels(typing.TypedDict, total=False):
     realm_offline: int
     player_watchlist: int
+    reoccuring_leaderboard: int
 
 
 class GuildConfig(PrismaGuildConfig):

--- a/common/playerlist_utils.py
+++ b/common/playerlist_utils.py
@@ -36,6 +36,19 @@ import common.utils as utils
 logger = logging.getLogger("realms_bot")
 
 
+REOCCURING_LB_FREQUENCY: dict[int, str] = {
+    1: "Every Sunday at 12:00 AM (00:00) UTC",
+    2: "Every other Sunday at 12:00 AM (00:00) UTC",
+    3: "The first Sunday of every month at 12:00 AM (00:00) UTC",
+}
+REOCCURING_LB_PERIODS: dict[int, str] = {
+    1: "24 hours",
+    2: "1 week",
+    3: "2 weeks",
+    4: "30 days",
+}
+
+
 def _convert_fields(value: tuple[str, ...] | None) -> tuple[str, ...]:
     return ("online", "last_seen") + value if value else ("online", "last_seen")
 

--- a/common/playerlist_utils.py
+++ b/common/playerlist_utils.py
@@ -287,7 +287,7 @@ async def invalidate_premium(
     config.live_playerlist = False
     config.fetch_devices = False
     config.live_online_channel = None
-    config.reoccuring_leaderboard = None
+    config.reoccurring_leaderboard = None
 
     await config.save()
 
@@ -335,7 +335,7 @@ async def eventually_invalidate(
         config.player_watchlist = []
         config.player_watchlist_role = None
         config.notification_channels = {}
-        config.reoccuring_leaderboard = None
+        config.reoccurring_leaderboard = None
         await config.save()
         await bot.redis.delete(
             f"invalid-playerlist3-{config.guild_id}",
@@ -453,28 +453,29 @@ async def eventually_invalidate_realm_offline(
                 await chan.send(msg)
 
 
-async def eventually_invalidate_reoccuring_lb(
+async def eventually_invalidate_reoccurring_lb(
     bot: utils.RealmBotBase, config: models.GuildConfig
 ) -> None:
     if not utils.FEATURE("EVENTUALLY_INVALIDATE"):
         return
 
-    num_times = await bot.redis.incr(f"invalid-realm-reoccuring-lb-{config.guild_id}")
+    num_times = await bot.redis.incr(f"invalid-realm-reoccurring-lb-{config.guild_id}")
 
     logger.info(
-        f"Increased invalid-reoccuring-lb for guild {config.guild_id} to {num_times}/3."
+        f"Increased invalid-reoccurring-lb for guild {config.guild_id} to"
+        f" {num_times}/3."
     )
 
-    await bot.redis.expire(f"invalid-realm-reoccuring-lb-{config.guild_id}", 87400)
+    await bot.redis.expire(f"invalid-realm-reoccurring-lb-{config.guild_id}", 87400)
 
     if num_times >= 3:
         logger.info(
-            f"Unlinking reoccuring leaderboard for guild {config.guild_id} with"
+            f"Unlinking reoccurring leaderboard for guild {config.guild_id} with"
             f" {num_times}/3 invalidations."
         )
 
-        config.reoccuring_leaderboard = None
-        old_chan = config.notification_channels.pop("reoccuring_leaderboard", None)
+        config.reoccurring_leaderboard = None
+        old_chan = config.notification_channels.pop("reoccurring_leaderboard", None)
         await config.save()
 
         if old_chan:
@@ -482,7 +483,7 @@ async def eventually_invalidate_reoccuring_lb(
                 chan = utils.partial_channel(bot, old_chan)
 
                 msg = (
-                    "The reoccuring leaderboard settings and channel has been unlinked"
+                    "The reoccurring leaderboard settings and channel has been unlinked"
                     " as the bot has not been able to properly send messages to it."
                     " Please check your permissions, make sure the bot has `View"
                     " Channel`, `Send Messages`, and `Embed Links` enabled, and then"

--- a/common/playerlist_utils.py
+++ b/common/playerlist_utils.py
@@ -36,19 +36,6 @@ import common.utils as utils
 logger = logging.getLogger("realms_bot")
 
 
-REOCCURING_LB_FREQUENCY: dict[int, str] = {
-    1: "Every Sunday at 12:00 AM (00:00) UTC",
-    2: "Every other Sunday at 12:00 AM (00:00) UTC",
-    3: "The first Sunday of every month at 12:00 AM (00:00) UTC",
-}
-REOCCURING_LB_PERIODS: dict[int, str] = {
-    1: "24 hours",
-    2: "1 week",
-    3: "2 weeks",
-    4: "30 days",
-}
-
-
 def _convert_fields(value: tuple[str, ...] | None) -> tuple[str, ...]:
     return ("online", "last_seen") + value if value else ("online", "last_seen")
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -274,6 +274,12 @@ async def config_info_generate(
         notification_channels += f"Player Watchlist Channel: <#{player_watchlist}>\n"
     if realm_offline := config.notification_channels.get("realm_offline"):
         notification_channels += f"Realm Offline Channel: <#{realm_offline}>\n"
+    if reoccuring_leaderboard := config.notification_channels.get(
+        "reoccuring_leaderboard"
+    ):
+        notification_channels += (
+            f"Reoccuring Leaderboard Channel: <#{reoccuring_leaderboard}>\n"
+        )
 
     notification_channels = notification_channels.strip()
 

--- a/common/utils.py
+++ b/common/utils.py
@@ -51,12 +51,12 @@ _debug_defaults = {
     "EVENTUALLY_INVALIDATE": True,
 }
 
-REOCCURING_LB_FREQUENCY: dict[int, str] = {
+REOCCURRING_LB_FREQUENCY: dict[int, str] = {
     1: "Every Sunday at 12:00 AM (00:00) UTC",
     2: "Every other Sunday at 12:00 AM (00:00) UTC",
     3: "The first Sunday of every month at 12:00 AM (00:00) UTC",
 }
-REOCCURING_LB_PERIODS: dict[int, str] = {
+REOCCURRING_LB_PERIODS: dict[int, str] = {
     1: "24 hours",
     2: "1 week",
     3: "2 weeks",
@@ -274,11 +274,11 @@ async def config_info_generate(
         notification_channels += f"Player Watchlist Channel: <#{player_watchlist}>\n"
     if realm_offline := config.notification_channels.get("realm_offline"):
         notification_channels += f"Realm Offline Channel: <#{realm_offline}>\n"
-    if reoccuring_leaderboard := config.notification_channels.get(
-        "reoccuring_leaderboard"
+    if reoccurring_leaderboard := config.notification_channels.get(
+        "reoccurring_leaderboard"
     ):
         notification_channels += (
-            f"Reoccuring Leaderboard Channel: <#{reoccuring_leaderboard}>\n"
+            f"Reoccuring Leaderboard Channel: <#{reoccurring_leaderboard}>\n"
         )
 
     notification_channels = notification_channels.strip()
@@ -306,10 +306,10 @@ async def config_info_generate(
             else "N/A"
         )
 
-        reoccuring_lb = (
-            f"{REOCCURING_LB_PERIODS[config.reoccuring_leaderboard % 10]} every"
-            f" {REOCCURING_LB_FREQUENCY[config.reoccuring_leaderboard // 10]}"
-            if config.reoccuring_leaderboard
+        reoccurring_lb = (
+            f"{REOCCURRING_LB_PERIODS[config.reoccurring_leaderboard % 10]} every"
+            f" {REOCCURRING_LB_FREQUENCY[config.reoccurring_leaderboard // 10]}"
+            if config.reoccurring_leaderboard
             else "N/A"
         )
 
@@ -320,7 +320,7 @@ async def config_info_generate(
             f" {toggle_friendly_str(config.live_playerlist)}\nLive Online Message:"
             f" {live_online_msg}\nDisplay Device Information:"
             f" {toggle_friendly_str(config.fetch_devices)}\nReoccuring Leaderboard:"
-            f" {reoccuring_lb}",
+            f" {reoccurring_lb}",
             inline=True,
         )
     else:
@@ -337,7 +337,7 @@ async def config_info_generate(
             f" {premium_code_id}\nPlayer Watchlist XUIDs:"
             f" {na_friendly_str(config.player_watchlist)}\nNotification Channels Dict:"
             f" {na_friendly_str(config.notification_channels)}\nReoccuring Leaderboard"
-            f" Value: {na_friendly_str(config.reoccuring_leaderboard)}\n"
+            f" Value: {na_friendly_str(config.reoccurring_leaderboard)}\n"
         )
         if config.premium_code:
             expires_at = (

--- a/common/utils.py
+++ b/common/utils.py
@@ -278,7 +278,7 @@ async def config_info_generate(
         "reoccurring_leaderboard"
     ):
         notification_channels += (
-            f"Reoccuring Leaderboard Channel: <#{reoccurring_leaderboard}>\n"
+            f"Reoccurring Leaderboard Channel: <#{reoccurring_leaderboard}>\n"
         )
 
     notification_channels = notification_channels.strip()
@@ -319,7 +319,7 @@ async def config_info_generate(
             f" {premium_linked_to}\nLive Playerlist:"
             f" {toggle_friendly_str(config.live_playerlist)}\nLive Online Message:"
             f" {live_online_msg}\nDisplay Device Information:"
-            f" {toggle_friendly_str(config.fetch_devices)}\nReoccuring Leaderboard:"
+            f" {toggle_friendly_str(config.fetch_devices)}\nReoccurring Leaderboard:"
             f" {reoccurring_lb}",
             inline=True,
         )
@@ -336,7 +336,7 @@ async def config_info_generate(
             f" ID:{na_friendly_str(config.realm_offline_role)}\nLinked Premium ID:"
             f" {premium_code_id}\nPlayer Watchlist XUIDs:"
             f" {na_friendly_str(config.player_watchlist)}\nNotification Channels Dict:"
-            f" {na_friendly_str(config.notification_channels)}\nReoccuring Leaderboard"
+            f" {na_friendly_str(config.notification_channels)}\nReoccurring Leaderboard"
             f" Value: {na_friendly_str(config.reoccurring_leaderboard)}\n"
         )
         if config.premium_code:

--- a/common/utils.py
+++ b/common/utils.py
@@ -51,6 +51,18 @@ _debug_defaults = {
     "EVENTUALLY_INVALIDATE": True,
 }
 
+REOCCURING_LB_FREQUENCY: dict[int, str] = {
+    1: "Every Sunday at 12:00 AM (00:00) UTC",
+    2: "Every other Sunday at 12:00 AM (00:00) UTC",
+    3: "The first Sunday of every month at 12:00 AM (00:00) UTC",
+}
+REOCCURING_LB_PERIODS: dict[int, str] = {
+    1: "24 hours",
+    2: "1 week",
+    3: "2 weeks",
+    4: "30 days",
+}
+
 
 def FEATURE(feature: str) -> bool:  # noqa: N802
     return _DEBUG.get(feature, _debug_defaults[feature])
@@ -287,14 +299,22 @@ async def config_info_generate(
             if config.premium_code and config.premium_code.user_id
             else "N/A"
         )
+
+        reoccuring_lb = (
+            f"{REOCCURING_LB_PERIODS[config.reoccuring_leaderboard % 10]} every"
+            f" {REOCCURING_LB_FREQUENCY[config.reoccuring_leaderboard // 10]}"
+            if config.reoccuring_leaderboard
+            else "N/A"
+        )
+
         embed.add_field(
             "Premium Information",
-            "Premium Active:"
-            f" {yesno_friendly_str(config.valid_premium)}\nLinked To:"
+            f"Premium Active: {yesno_friendly_str(config.valid_premium)}\nLinked To:"
             f" {premium_linked_to}\nLive Playerlist:"
-            f" {toggle_friendly_str(config.live_playerlist)}\nLive Online"
-            f" Message: {live_online_msg}\nDisplay Device Information:"
-            f" {toggle_friendly_str(config.fetch_devices)}",
+            f" {toggle_friendly_str(config.live_playerlist)}\nLive Online Message:"
+            f" {live_online_msg}\nDisplay Device Information:"
+            f" {toggle_friendly_str(config.fetch_devices)}\nReoccuring Leaderboard:"
+            f" {reoccuring_lb}",
             inline=True,
         )
     else:
@@ -310,7 +330,8 @@ async def config_info_generate(
             f" ID:{na_friendly_str(config.realm_offline_role)}\nLinked Premium ID:"
             f" {premium_code_id}\nPlayer Watchlist XUIDs:"
             f" {na_friendly_str(config.player_watchlist)}\nNotification Channels Dict:"
-            f" {na_friendly_str(config.notification_channels)}"
+            f" {na_friendly_str(config.notification_channels)}\nReoccuring Leaderboard"
+            f" Value: {na_friendly_str(config.reoccuring_leaderboard)}\n"
         )
         if config.premium_code:
             expires_at = (

--- a/exts/autorunners.py
+++ b/exts/autorunners.py
@@ -78,10 +78,12 @@ class Autorunners(utils.Extension):
     def __init__(self, bot: utils.RealmBotBase) -> None:
         self.bot: utils.RealmBotBase = bot
         self.playerlist_task = self.bot.create_task(self._start_playerlist())
+        self.reoccuring_lb_task = self.bot.create_task(self._start_reoccurring_lb())
         self.player_session_delete.start()
 
     def drop(self) -> None:
         self.playerlist_task.cancel()
+        self.reoccuring_lb_task.cancel()
         self.player_session_delete.stop()
         super().drop()
 

--- a/exts/autorunners.py
+++ b/exts/autorunners.py
@@ -198,13 +198,13 @@ class Autorunners(utils.Extension):
                 await utils.error_handle(e)
 
     async def reoccuring_lb_loop(
-        self, the_second_sunday: bool, first_monday_of_month: bool
+        self, second_sunday: bool, first_monday_of_month: bool
     ) -> None:
         lb_command = next(
             c for c in self.bot.application_commands if str(c.name) == "leaderboard"
         )
 
-        if the_second_sunday and first_monday_of_month:
+        if second_sunday and first_monday_of_month:
             configs = await models.GuildConfig.prisma().find_many(
                 where={
                     "guild_id": {"in": [int(g) for g in self.bot.user._guild_ids]},
@@ -223,7 +223,7 @@ class Autorunners(utils.Extension):
                 },
                 include={"premium_code": True},
             )
-        elif the_second_sunday:
+        elif second_sunday:
             configs = await models.GuildConfig.prisma().find_many(
                 where={
                     "guild_id": {"in": [int(g) for g in self.bot.user._guild_ids]},

--- a/exts/guild_config.py
+++ b/exts/guild_config.py
@@ -701,11 +701,16 @@ class GuildConfig(utils.Extension):
     async def set_notification_channel(
         self,
         ctx: utils.RealmContext,
-        feature: typing.Literal["player_watchlist", "realm_offline"] = tansy.Option(
+        feature: typing.Literal[
+            "player_watchlist", "realm_offline", "reoccuring_leaderboard"
+        ] = tansy.Option(
             "The feature/notification type to set the channel for.",
             choices=[
                 ipy.SlashCommandChoice("Player Watchlist", "player_watchlist"),
                 ipy.SlashCommandChoice("Realm Offline Notifications", "realm_offline"),
+                ipy.SlashCommandChoice(
+                    "Reoccuring Leaderboard", "reoccuring_leaderboard"
+                ),
             ],
             type=str,
         ),

--- a/exts/guild_config.py
+++ b/exts/guild_config.py
@@ -702,14 +702,14 @@ class GuildConfig(utils.Extension):
         self,
         ctx: utils.RealmContext,
         feature: typing.Literal[
-            "player_watchlist", "realm_offline", "reoccuring_leaderboard"
+            "player_watchlist", "realm_offline", "reoccurring_leaderboard"
         ] = tansy.Option(
             "The feature/notification type to set the channel for.",
             choices=[
                 ipy.SlashCommandChoice("Player Watchlist", "player_watchlist"),
                 ipy.SlashCommandChoice("Realm Offline Notifications", "realm_offline"),
                 ipy.SlashCommandChoice(
-                    "Reoccuring Leaderboard", "reoccuring_leaderboard"
+                    "Reoccuring Leaderboard", "reoccurring_leaderboard"
                 ),
             ],
             type=str,

--- a/exts/guild_config.py
+++ b/exts/guild_config.py
@@ -709,7 +709,7 @@ class GuildConfig(utils.Extension):
                 ipy.SlashCommandChoice("Player Watchlist", "player_watchlist"),
                 ipy.SlashCommandChoice("Realm Offline Notifications", "realm_offline"),
                 ipy.SlashCommandChoice(
-                    "Reoccuring Leaderboard", "reoccurring_leaderboard"
+                    "Reoccurring Leaderboard", "reoccurring_leaderboard"
                 ),
             ],
             type=str,

--- a/exts/owner_cmds.py
+++ b/exts/owner_cmds.py
@@ -447,7 +447,7 @@ class OwnerCMDs(utils.Extension):
     async def trigger_autorunning_playerlist(
         self, ctx: utils.RealmPrefixedContext
     ) -> None:
-        await self.bot.ext["AutoRunPlayerlist"].playerlist_loop(None)  # type: ignore
+        await self.bot.ext["Autorunners"].playerlist_loop(None)  # type: ignore
         await ctx.reply("Done!")
 
     @blacklist.subcommand(name="remove", aliases=["delete"])

--- a/exts/owner_cmds.py
+++ b/exts/owner_cmds.py
@@ -450,6 +450,20 @@ class OwnerCMDs(utils.Extension):
         await self.bot.ext["Autorunners"].playerlist_loop(None)  # type: ignore
         await ctx.reply("Done!")
 
+    @debug.subcommand(
+        aliases=["trigger-reoccuring-leaderboard", "trigger-reoccuring-lb"]
+    )
+    async def trigger_reoccuring_leaderboard(
+        self,
+        ctx: utils.RealmPrefixedContext,
+        second_sunday: bool,
+        first_monday_of_month: bool,
+    ) -> None:
+        await self.bot.ext["Autorunners"].reoccuring_lb_loop(  # type: ignore
+            second_sunday, first_monday_of_month
+        )
+        await ctx.reply("Done!")
+
     @blacklist.subcommand(name="remove", aliases=["delete"])
     async def bl_remove(
         self, ctx: utils.RealmPrefixedContext, snowflake: ipy.SnowflakeObject

--- a/exts/owner_cmds.py
+++ b/exts/owner_cmds.py
@@ -451,15 +451,15 @@ class OwnerCMDs(utils.Extension):
         await ctx.reply("Done!")
 
     @debug.subcommand(
-        aliases=["trigger-reoccuring-leaderboard", "trigger-reoccuring-lb"]
+        aliases=["trigger-reoccurring-leaderboard", "trigger-reoccurring-lb"]
     )
-    async def trigger_reoccuring_leaderboard(
+    async def trigger_reoccurring_leaderboard(
         self,
         ctx: utils.RealmPrefixedContext,
         second_sunday: bool,
         first_monday_of_month: bool,
     ) -> None:
-        await self.bot.ext["Autorunners"].reoccuring_lb_loop(  # type: ignore
+        await self.bot.ext["Autorunners"].reoccurring_lb_loop(  # type: ignore
             second_sunday, first_monday_of_month
         )
         await ctx.reply("Done!")

--- a/exts/premium.py
+++ b/exts/premium.py
@@ -448,6 +448,70 @@ class PremiumHandling(ipy.Extension):
             csv_io.close()
 
     @premium.subcommand(
+        sub_cmd_name="reoccuring-leaderboard",
+        sub_cmd_description=(
+            "Configures a leaderboard that is sent at a certain frequency. Premium"
+            " only."
+        ),
+    )
+    @premium_check()
+    async def reoccuring_leaderboard(
+        self,
+        ctx: utils.RealmContext,
+        toggle: bool = tansy.Option("Should it be turned on (true) or off (false)?"),
+        frequency: int | None = tansy.Option(
+            "How often the leaderboard should be sent.",
+            choices=[
+                ipy.SlashCommandChoice("Every Sunday at 12:00 AM (00:00) UTC", 1),
+                ipy.SlashCommandChoice("Every other Sunday at 12:00 AM (00:00) UTC", 2),
+                ipy.SlashCommandChoice(
+                    "The first Sunday of every month at 12:00 AM (00:00) UTC", 3
+                ),
+            ],
+            default=None,
+        ),
+        period: int | None = tansy.Option(
+            "The period to gather data for each leaderboard for.",
+            choices=[
+                ipy.SlashCommandChoice("24 hours", 1),
+                ipy.SlashCommandChoice("1 week", 2),
+                ipy.SlashCommandChoice("2 weeks", 3),
+                ipy.SlashCommandChoice("30 days", 4),
+            ],
+            default=None,
+        ),
+    ) -> None:
+        if toggle:
+            if not frequency or not period:
+                raise ipy.errors.BadArgument(
+                    "You must provide a frequency and period when enabling this"
+                    " feature!"
+                )
+
+            config = await ctx.fetch_config()
+
+            config.reoccuring_leaderboard = (frequency * 10) + period
+            await config.save()
+
+            # TODO: add what was it set as
+            await ctx.send(
+                "Set the reoccuring leaderboard!",
+            )
+
+        else:
+            config = await ctx.fetch_config()
+
+            if not config.reoccuring_leaderboard:
+                raise ipy.errors.BadArgument(
+                    "The reoccuring leaderboard hasn't been set yet!"
+                )
+
+            config.reoccuring_leaderboard = None
+            await config.save()
+
+            await ctx.send("Disabled the reoccuring leaderboard.")
+
+    @premium.subcommand(
         sub_cmd_name="info",
         sub_cmd_description=(
             "Gives you information about Realms Playerlist Premium and how to get it."

--- a/exts/premium.py
+++ b/exts/premium.py
@@ -502,10 +502,13 @@ class PremiumHandling(ipy.Extension):
             await config.save()
 
             await ctx.send(
-                "Set the reoccurring leaderboard to run"
-                f" {utils.REOCCURRING_LB_FREQUENCY[frequency]} with a period of"
-                f" {utils.REOCCURRING_LB_PERIODS[period]}, sending the leaderboard to"
-                f" <#{config.notification_channels.get('reoccurring_leaderboard', config.playerlist_chan)}>.",
+                embed=utils.make_embed(
+                    "Set the reoccurring leaderboard to run"
+                    f" {utils.REOCCURRING_LB_FREQUENCY[frequency]} with a period of"
+                    f" {utils.REOCCURRING_LB_PERIODS[period]}, sending the"
+                    " leaderboard to"
+                    f" <#{config.notification_channels.get('reoccurring_leaderboard', config.playerlist_chan)}>."
+                ),
             )
 
         else:
@@ -518,7 +521,9 @@ class PremiumHandling(ipy.Extension):
             config.notification_channels.pop("reoccurring_leaderboard", None)
             await config.save()
 
-            await ctx.send("Disabled the reoccurring leaderboard.")
+            await ctx.send(
+                embed=utils.make_embed("Disabled the reoccurring leaderboard.")
+            )
 
     @premium.subcommand(
         sub_cmd_name="info",

--- a/exts/premium.py
+++ b/exts/premium.py
@@ -462,21 +462,16 @@ class PremiumHandling(ipy.Extension):
         frequency: int | None = tansy.Option(
             "How often the leaderboard should be sent.",
             choices=[
-                ipy.SlashCommandChoice("Every Sunday at 12:00 AM (00:00) UTC", 1),
-                ipy.SlashCommandChoice("Every other Sunday at 12:00 AM (00:00) UTC", 2),
-                ipy.SlashCommandChoice(
-                    "The first Sunday of every month at 12:00 AM (00:00) UTC", 3
-                ),
+                ipy.SlashCommandChoice(v, k)
+                for k, v in pl_utils.REOCCURING_LB_FREQUENCY.items()
             ],
             default=None,
         ),
         period: int | None = tansy.Option(
             "The period to gather data for each leaderboard for.",
             choices=[
-                ipy.SlashCommandChoice("24 hours", 1),
-                ipy.SlashCommandChoice("1 week", 2),
-                ipy.SlashCommandChoice("2 weeks", 3),
-                ipy.SlashCommandChoice("30 days", 4),
+                ipy.SlashCommandChoice(v, k)
+                for k, v in pl_utils.REOCCURING_LB_PERIODS.items()
             ],
             default=None,
         ),
@@ -493,9 +488,10 @@ class PremiumHandling(ipy.Extension):
             config.reoccuring_leaderboard = (frequency * 10) + period
             await config.save()
 
-            # TODO: add what was it set as
             await ctx.send(
-                "Set the reoccuring leaderboard!",
+                "Set the reoccuring leaderboard to run"
+                f" {pl_utils.REOCCURING_LB_FREQUENCY[frequency]} with a period of"
+                f" {pl_utils.REOCCURING_LB_PERIODS[period]}",
             )
 
         else:

--- a/exts/premium.py
+++ b/exts/premium.py
@@ -504,7 +504,7 @@ class PremiumHandling(ipy.Extension):
             await ctx.send(
                 "Set the reoccuring leaderboard to run"
                 f" {utils.REOCCURING_LB_FREQUENCY[frequency]} with a period of"
-                f" {utils.REOCCURING_LB_PERIODS[period]}, sending the message to"
+                f" {utils.REOCCURING_LB_PERIODS[period]}, sending the leaderboard to"
                 f" <#{config.notification_channels.get('reoccuring_leaderboard', config.playerlist_chan)}>.",
             )
 

--- a/exts/premium.py
+++ b/exts/premium.py
@@ -448,14 +448,14 @@ class PremiumHandling(ipy.Extension):
             csv_io.close()
 
     @premium.subcommand(
-        sub_cmd_name="reoccuring-leaderboard",
+        sub_cmd_name="reoccurring-leaderboard",
         sub_cmd_description=(
             "Configures a leaderboard that is sent at a certain frequency. Premium"
             " only."
         ),
     )
     @premium_check()
-    async def reoccuring_leaderboard(
+    async def reoccurring_leaderboard(
         self,
         ctx: utils.RealmContext,
         toggle: bool = tansy.Option("Should it be turned on (true) or off (false)?"),
@@ -463,7 +463,7 @@ class PremiumHandling(ipy.Extension):
             "How often the leaderboard should be sent.",
             choices=[
                 ipy.SlashCommandChoice(v, k)
-                for k, v in utils.REOCCURING_LB_FREQUENCY.items()
+                for k, v in utils.REOCCURRING_LB_FREQUENCY.items()
             ],
             default=None,
         ),
@@ -471,7 +471,7 @@ class PremiumHandling(ipy.Extension):
             "The period to gather data for each leaderboard for.",
             choices=[
                 ipy.SlashCommandChoice(v, k)
-                for k, v in utils.REOCCURING_LB_PERIODS.items()
+                for k, v in utils.REOCCURRING_LB_PERIODS.items()
             ],
             default=None,
         ),
@@ -496,29 +496,29 @@ class PremiumHandling(ipy.Extension):
                     " feature!"
                 )
 
-            config.reoccuring_leaderboard = (frequency * 10) + period
+            config.reoccurring_leaderboard = (frequency * 10) + period
             if channel:
-                config.notification_channels["reoccuring_leaderboard"] = channel.id
+                config.notification_channels["reoccurring_leaderboard"] = channel.id
             await config.save()
 
             await ctx.send(
-                "Set the reoccuring leaderboard to run"
-                f" {utils.REOCCURING_LB_FREQUENCY[frequency]} with a period of"
-                f" {utils.REOCCURING_LB_PERIODS[period]}, sending the leaderboard to"
-                f" <#{config.notification_channels.get('reoccuring_leaderboard', config.playerlist_chan)}>.",
+                "Set the reoccurring leaderboard to run"
+                f" {utils.REOCCURRING_LB_FREQUENCY[frequency]} with a period of"
+                f" {utils.REOCCURRING_LB_PERIODS[period]}, sending the leaderboard to"
+                f" <#{config.notification_channels.get('reoccurring_leaderboard', config.playerlist_chan)}>.",
             )
 
         else:
-            if not config.reoccuring_leaderboard:
+            if not config.reoccurring_leaderboard:
                 raise ipy.errors.BadArgument(
-                    "The reoccuring leaderboard hasn't been set yet!"
+                    "The reoccurring leaderboard hasn't been set yet!"
                 )
 
-            config.reoccuring_leaderboard = None
-            config.notification_channels.pop("reoccuring_leaderboard", None)
+            config.reoccurring_leaderboard = None
+            config.notification_channels.pop("reoccurring_leaderboard", None)
             await config.save()
 
-            await ctx.send("Disabled the reoccuring leaderboard.")
+            await ctx.send("Disabled the reoccurring leaderboard.")
 
     @premium.subcommand(
         sub_cmd_name="info",

--- a/exts/premium.py
+++ b/exts/premium.py
@@ -463,7 +463,7 @@ class PremiumHandling(ipy.Extension):
             "How often the leaderboard should be sent.",
             choices=[
                 ipy.SlashCommandChoice(v, k)
-                for k, v in pl_utils.REOCCURING_LB_FREQUENCY.items()
+                for k, v in utils.REOCCURING_LB_FREQUENCY.items()
             ],
             default=None,
         ),
@@ -471,7 +471,7 @@ class PremiumHandling(ipy.Extension):
             "The period to gather data for each leaderboard for.",
             choices=[
                 ipy.SlashCommandChoice(v, k)
-                for k, v in pl_utils.REOCCURING_LB_PERIODS.items()
+                for k, v in utils.REOCCURING_LB_PERIODS.items()
             ],
             default=None,
         ),
@@ -490,8 +490,8 @@ class PremiumHandling(ipy.Extension):
 
             await ctx.send(
                 "Set the reoccuring leaderboard to run"
-                f" {pl_utils.REOCCURING_LB_FREQUENCY[frequency]} with a period of"
-                f" {pl_utils.REOCCURING_LB_PERIODS[period]}",
+                f" {utils.REOCCURING_LB_FREQUENCY[frequency]} with a period of"
+                f" {utils.REOCCURING_LB_PERIODS[period]}",
             )
 
         else:

--- a/exts/premium.py
+++ b/exts/premium.py
@@ -476,8 +476,8 @@ class PremiumHandling(ipy.Extension):
             default=None,
         ),
         channel: ipy.GuildText | None = tansy.Option(
-            "The channel to send the leaderboard to. Defaults to the autorunning"
-            " playerlist channel.",
+            "The channel to send the leaderboard to. If not set, defaults to the"
+            " autorunning playerlist channel.",
             converter=cclasses.ValidChannelConverter,
         ),
     ) -> None:

--- a/exts/premium.py
+++ b/exts/premium.py
@@ -504,7 +504,7 @@ class PremiumHandling(ipy.Extension):
             await ctx.send(
                 "Set the reoccuring leaderboard to run"
                 f" {utils.REOCCURING_LB_FREQUENCY[frequency]} with a period of"
-                f" {utils.REOCCURING_LB_PERIODS[period]}, sending to"
+                f" {utils.REOCCURING_LB_PERIODS[period]}, sending the message to"
                 f" <#{config.notification_channels.get('reoccuring_leaderboard', config.playerlist_chan)}>.",
             )
 

--- a/exts/statistics.py
+++ b/exts/statistics.py
@@ -469,7 +469,7 @@ class Statistics(utils.Extension):
     @ipy.check(pl_utils.has_linked_realm)
     async def leaderboard(
         self,
-        ctx: utils.RealmContext,
+        ctx: utils.RealmContext | utils.RealmPrefixedContext,
         period: int = tansy.Option(
             "The period to gather data for.",
             choices=[

--- a/migrations/20231221205121_reoccurring_leaderboard/migration.sql
+++ b/migrations/20231221205121_reoccurring_leaderboard/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "realmguildconfig" ADD COLUMN     "reoccurring_leaderboard" INTEGER;

--- a/schema.prisma
+++ b/schema.prisma
@@ -10,20 +10,21 @@ generator client {
 }
 
 model GuildConfig {
-  guild_id              BigInt            @id @default(autoincrement())
-  club_id               String?           @db.VarChar(50)
-  playerlist_chan       BigInt?
-  realm_id              String?           @db.VarChar(50)
-  live_playerlist       Boolean           @default(false)
-  realm_offline_role    BigInt?
-  warning_notifications Boolean           @default(true)
-  premium_code_id       Int?
-  fetch_devices         Boolean           @default(false)
-  live_online_channel   String?           @db.VarChar(75)
-  player_watchlist_role BigInt?
-  player_watchlist      String[]          @default([])
-  notification_channels Json              @db.JsonB @default("{}")
-  premium_code      PremiumCode? @relation(fields: [premium_code_id], references: [id], onUpdate: NoAction)
+  guild_id               BigInt       @id @default(autoincrement())
+  club_id                String?      @db.VarChar(50)
+  playerlist_chan        BigInt?
+  realm_id               String?      @db.VarChar(50)
+  live_playerlist        Boolean      @default(false)
+  realm_offline_role     BigInt?
+  warning_notifications  Boolean      @default(true)
+  premium_code_id        Int?
+  fetch_devices          Boolean      @default(false)
+  live_online_channel    String?      @db.VarChar(75)
+  player_watchlist_role  BigInt?
+  player_watchlist       String[]     @default([])
+  notification_channels  Json         @default("{}") @db.JsonB
+  reoccuring_leaderboard Int?
+  premium_code           PremiumCode? @relation(fields: [premium_code_id], references: [id], onUpdate: NoAction)
 
   @@map("realmguildconfig")
 }
@@ -40,14 +41,14 @@ model PlayerSession {
 }
 
 model PremiumCode {
-  id               Int                @id @default(autoincrement())
-  code             String             @db.VarChar(100)
-  user_id          BigInt?
-  uses             Int                @default(0)
-  max_uses         Int                @default(2)
-  customer_id      String?            @db.VarChar(50)
-  expires_at       DateTime?          @db.Timestamptz(6)
-  guilds GuildConfig[]
+  id          Int           @id @default(autoincrement())
+  code        String        @db.VarChar(100)
+  user_id     BigInt?
+  uses        Int           @default(0)
+  max_uses    Int           @default(2)
+  customer_id String?       @db.VarChar(50)
+  expires_at  DateTime?     @db.Timestamptz(6)
+  guilds      GuildConfig[]
 
   @@map("realmpremiumcode")
 }

--- a/schema.prisma
+++ b/schema.prisma
@@ -23,7 +23,7 @@ model GuildConfig {
   player_watchlist_role  BigInt?
   player_watchlist       String[]     @default([])
   notification_channels  Json         @default("{}") @db.JsonB
-  reoccuring_leaderboard Int?
+  reoccurring_leaderboard Int?
   premium_code           PremiumCode? @relation(fields: [premium_code_id], references: [id], onUpdate: NoAction)
 
   @@map("realmguildconfig")


### PR DESCRIPTION
Adds a reoccurring leaderboard, which allows sending the `/leaderboard` with a set period on a specified frequency. Premium only, WIP.